### PR TITLE
perf: replace_row is ~60x faster

### DIFF
--- a/src/visit/linear_algebra_visitor.js
+++ b/src/visit/linear_algebra_visitor.js
@@ -240,8 +240,8 @@ class LinearAlgebra extends ProcessChainVisitor {
         let c = 0;
         while (c < row.length) {
             // fix floating point things here?
-            let val = (Math.abs(row[c]) < 1e-12) ? 0 : row[c];
-            m1 = m1.replace(idx, c, val);
+            const val = (Math.abs(row[c]) < 1e-12) ? 0 : row[c];
+            m1.data[idx][c] = val;
             c++;
         }
         return m1;


### PR DESCRIPTION
Cut the execution time of `build` on a moderate size matrix by ~60x.

`replace()` is apparently quite expensive, possibly due to the unnecessary implementation of lodash's `cloneDeep` used internally. We don't care about Matrix being immutable here, as we've already copied it (in `scale`), so just mutate it directly.